### PR TITLE
docs(deploy): fix both docs and app deploying to same target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Build application
         run: yarn build
 
+      - name: Download documentation artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/download-artifact@v4
+        with:
+          name: documentation
+          path: ./dist/docs/
+        continue-on-error: true
+
       - name: Setup Pages
         if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy MkDocs Documentation
+name: Build Documentation
 
 on:
   push:
@@ -16,12 +16,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -37,24 +31,13 @@ jobs:
 
       - name: Install MkDocs
         run: |
-          pip install mkdocs
+          python3 -m pip install mkdocs
 
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: documentation
           path: site/
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: KidPix Documentation
 site_description: Documentation for the KidPix drawing application
 site_author: KidPix Project
-site_url: https://justinpearson.github.io/kidpix
+site_url: https://justinpearson.github.io/kidpix/docs
 
 repo_name: justinpearson/kidpix
 repo_url: https://github.com/justinpearson/kidpix


### PR DESCRIPTION
## Summary

- Configure GitHub Actions to deploy both documentation and application to GitHub Pages
- Merge documentation build artifact into application deployment workflow
- Update site URL configuration to serve docs at `/docs` subdirectory

## Changes

- Modified `.github/workflows/deploy.yml` to download documentation artifact and include in Pages deployment
- Updated `.github/workflows/docs.yml` to build documentation as artifact instead of deploying separately
- Changed `mkdocs.yml` site URL to point to the `/docs` subdirectory

## Test plan

- [ ] Verify GitHub Actions workflows pass
- [ ] Confirm documentation builds successfully as artifact
- [ ] Test that both app and docs are accessible at correct URLs after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)