### PR TITLE
fix broken releases

### DIFF
--- a/.claude/commands/jp-server-start.md
+++ b/.claude/commands/jp-server-start.md
@@ -1,4 +1,4 @@
-Launch the local dev server using `yarn dev` in a sub-shell and let me know if
+Launch the local dev server using `yarn dev-app` in a sub-shell and let me know if
 you see any errors on its stdout / stderr. Recall that this project is
 configured to log **browser console errors** to the dev server's stdout, so
 the User's actions in the app may result in errors displaying in the dev

--- a/.claude/commands/jp-server-start.md
+++ b/.claude/commands/jp-server-start.md
@@ -1,1 +1,7 @@
-Launch the local dev server using `yarn dev` in a sub-shell and let me know if you see any errors on its stdout / stderr. Recall that this project is configured to log **browser console errors** to the dev server's stdout, so the User's actions in the app may result in errors displaying in the dev server's stdout. Remember to check its stdout before and after each user notification, to catch any browser errors right away, and report them to the User for consideration / debugging.
+Launch the local dev server using `yarn dev` in a sub-shell and let me know if
+you see any errors on its stdout / stderr. Recall that this project is
+configured to log **browser console errors** to the dev server's stdout, so
+the User's actions in the app may result in errors displaying in the dev
+server's stdout. Remember to check its stdout before and after each user
+notification, to catch any browser errors right away, and report them to the
+User for consideration / debugging.

--- a/.claude/commands/jp-server-stop.md
+++ b/.claude/commands/jp-server-stop.md
@@ -1,11 +1,11 @@
-Stop the local dev server (`vite`, from `yarn dev`) in the following way:
+Stop the local dev server (`vite`, from `yarn dev-app`) in the following way:
 
 If vite / yarn dev is running in your sub-shell, retrieve any last stdout /
 stderr lines from the sub-shell, report them to the User, and consider
 debugging them. Then simply type 'q' and ENTER to stop vite.
 
-If that doesn't work, try running `yarn dev-stop` -- the `package.json` file
-defines a script `yarn dev-stop` that kills the pid recorded in `.vite.pid`.
+If that doesn't work, try running `yarn dev-app-stop` -- the `package.json` file
+defines a script `yarn dev-app-stop` that kills the pid recorded in `.vite.pid`.
 
 If THAT doesn't work, you might have to see if there's a vite process running
 elsewhere. Be careful to only kill vite processes for THIS project

--- a/.claude/commands/jp-server-stop.md
+++ b/.claude/commands/jp-server-stop.md
@@ -1,7 +1,13 @@
 Stop the local dev server (`vite`, from `yarn dev`) in the following way:
 
-If vite / yarn dev is running in your sub-shell, retrieve any last stdout / stderr lines from the sub-shell, report them to the User, and consider debugging them. Then simply type 'q' and ENTER to stop vite.
+If vite / yarn dev is running in your sub-shell, retrieve any last stdout /
+stderr lines from the sub-shell, report them to the User, and consider
+debugging them. Then simply type 'q' and ENTER to stop vite.
 
-If that doesn't work, try running `yarn dev-stop` -- the `package.json` file defines a script `yarn dev-stop` that kills the pid recorded in `.vite.pid`.
+If that doesn't work, try running `yarn dev-stop` -- the `package.json` file
+defines a script `yarn dev-stop` that kills the pid recorded in `.vite.pid`.
 
-If THAT doesn't work, you might have to see if there's a vite process running elsewhere. Be careful to only kill vite processes for THIS project (kidpix), and not other vite processes that may be locally running other apps.
+If THAT doesn't work, you might have to see if there's a vite process running
+elsewhere. Be careful to only kill vite processes for THIS project
+(kidpix), and not other vite processes that may be locally running other
+apps.

--- a/.github/workflows/build-and-deploy-all.yml
+++ b/.github/workflows/build-and-deploy-all.yml
@@ -36,12 +36,12 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: pip install -r requirements.txt
       - run: pip install mkdocs
-      - run: yarn build:github-pages:site # must run: Vite -> dist/, MkDocs -> dist/docs
+      - run: yarn build
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: dist-gh
 
   deploy:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,13 @@ jobs:
           files: kidpix-${{ github.ref_name }}.tar.gz
           name: "Justin's KidPix fork ${{ github.ref_name }} - Release"
           body: |
-            # Justin's KidPix ${{ github.ref_name }} - Classic Drawing App
-
-            Automated release of my fork of vikrum's HTML/JS re-implementation of the public-domain 1989 Kid Pix program.
-
-            ## Features
-            - 🎨 All original drawing tools (pencil, brush, paint bucket, etc.)  
-            - 🖼️ Wacky brushes with animated effects
-            - 🎵 Original sound effects for each tool
-            - 🎯 Stamps and text tools
-            - 🌈 Multi-layer canvas system
-            - 💾 Save/load functionality
+            My fork of vikrum's HTML/JS re-implementation of the public-domain 1989 Kid Pix program.
 
             ## How to Run
             1. Download the `kidpix-${{ github.ref_name }}.tar.gz` file below
             2. Extract the archive to a folder
             3. Run a local web server in the extracted folder (e.g., `python -m http.server` or `npx serve .`)
-            4. Open the served URL in your browser
+            4. Open the served URL in your browser, eg, http://localhost:8080/
             5. Start drawing!
 
             Enjoy creating digital masterpieces! 🎨

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-gh
 dist-ssr
 *.local
 
@@ -44,3 +45,4 @@ site/
 tmp/
 .vite.pid
 
+.playwright-mcp

--- a/package.json
+++ b/package.json
@@ -3,26 +3,15 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "comments": {
-    "dev:app": "Visit http://localhost:5173/kidpix/ (vite runs with base=/kidpix/)",
-    "dev:docs": "Visit http://localhost:8000/ (mkdocs live server, no subpath)",
-    "build:site": "Build app into dist/ and docs into dist/docs/",
-    "preview:site": "Serve dist/ at http://localhost:8080/kidpix/ and /kidpix/docs/"
-  },
   "scripts": {
-    "dev:docs": "mkdocs serve -a 127.0.0.1:8000",
-    "build": "vite build",
-    "build:github-pages": "VITE_GITHUB_PAGES=true vite build",
-    "docs:build": "mkdocs build --site-dir dist/docs",
-    "build:site": "yarn build && yarn docs:build",
-    "build:github-pages:site": "yarn build:github-pages && yarn docs:build",
-    "build:preview": "NODE_ENV=development vite build",
-    "preview:site": "yarn build:preview && python3 -m http.server 8080 --directory dist",
-    "dev": "vite & echo $! > .vite.pid",
-    "dev-stop": "kill $(cat .vite.pid 2>/dev/null) 2>/dev/null && rm -f .vite.pid || true",
-    "docs:dev:OLD": "mkdocs serve",
-    "build:OLD": "tsc -b && vite build",
-    "docs:build:OLD": "mkdocs build",
+    "dev-app": "vite dev & echo $! > .vite.pid",
+    "dev-app-stop": "kill $(cat .vite.pid 2>/dev/null) 2>/dev/null && rm -f .vite.pid || true",
+    "dev-docs": "mkdocs serve",
+
+    "build": "vite build --outDir dist --base=/ && mkdocs build --site-dir dist/docs && vite build --outDir dist-gh/kidpix --base=/kidpix/ && mkdocs build --site-dir dist-gh/kidpix/docs",
+    "preview-release": "python3 -m http.server 8080 --directory dist",
+    "preview-github-pages": "echo \"WARNING: SERVING APP AT http://localhost:8080/kidpix/ , NOTE THE /kidpix/ !! \" && python3 -m http.server 8080 --directory dist-gh",
+
     "test": "vitest run",
     "test:unit": "vitest",
     "test:unit:ui": "vitest --ui",
@@ -33,14 +22,12 @@
     "test:e2e:ui": "playwright test --ui --reporter=line",
     "test:e2e:single": "playwright test tests/e2e/pencil.spec.ts --project=chromium --workers=1 --reporter=line",
     "test:e2e:showlastreport": "playwright show-report",
-    "screenshot": "node scripts/screenshot-capture.js",
+
     "release:patch": "npm version patch && git push origin --tags",
     "release:minor": "npm version minor && git push origin --tags",
     "release:major": "npm version major && git push origin --tags",
-    "preview": "vite preview",
-    "type-check": "tsc -p tsconfig.app.json --noEmit",
-    "type-check:watch": "tsc --noEmit --watch",
-    "types:generate": "tsc --declaration --emitDeclarationOnly --outDir types/generated"
+    
+    "screenshot": "node scripts/screenshot-capture.js",
   },
   "dependencies": {},
   "devDependencies": {

--- a/prompts-TODO/misc.txt
+++ b/prompts-TODO/misc.txt
@@ -6,6 +6,47 @@ Once groomed / well-formed, move to backlog.txt.
 
 
 ===============================================================
+Bug: releases don't work, eg, kidpix-v1.0.0.zip
+===============================================================
+
+```
+√ 2025-09-21 7:19:34 tmp  % cd /Users/justin/Downloads/kidpix-v1.0.0
+√ 2025-09-21 15:32:02 kidpix-v1.0.0  % ls
+assets    css   img   index.html  snd   static
+√ 2025-09-21 15:32:02 kidpix-v1.0.0  % p3 -m http.server
+Serving HTTP on :: port 8000 (http://[::]:8000/) ...
+::1 - - [21/Sep/2025 15:32:14] "GET / HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] code 404, message File not found
+::1 - - [21/Sep/2025 15:32:14] "GET /.well-known/appspecific/com.chrome.devtools.json HTTP/1.1" 404 -
+::1 - - [21/Sep/2025 15:32:14] "GET /css/kidpix.css HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] code 404, message File not found
+::1 - - [21/Sep/2025 15:32:14] "GET /kidpix/assets/main-BtFJm_MT.js HTTP/1.1" 404 -
+::1 - - [21/Sep/2025 15:32:14] code 404, message File not found
+::1 - - [21/Sep/2025 15:32:14] "GET /kidpix/assets/main-BwliJ-KA.css HTTP/1.1" 404 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_27.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_28.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_29.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_30.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_31.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_34.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_33.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_32.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_35.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_36.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/eyedropper-icon.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_40.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_39.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_37.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kp-m_38.png HTTP/1.1" 200 -
+::1 - - [21/Sep/2025 15:32:14] "GET /img/kidpix.png HTTP/1.1" 200 -
+^C
+Keyboard interrupt received, exiting.
+√ 2025-09-21 15:32:19 kidpix-v1.0.0  % pwd
+kidpix/tmp/kidpix-v1.0.0/ or smt
+```
+
+
+===============================================================
 Feature: ensure all tools make sounds
 ===============================================================
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     }),
   ],
   // base: process.env.NODE_ENV === "production" ? "/kidpix/" : "/", // OLD
-  base: process.env.VITE_GITHUB_PAGES === "true" ? "/kidpix/" : "/",
+  // base: process.env.VITE_GITHUB_PAGES === "true" ? "/kidpix/" : "/", // OLD 2
+  base: "/",
   publicDir: "src/assets", // Copy src/assets to build output
   server: {
     port: 5173,


### PR DESCRIPTION
- Simplify scripts in package.json to make it easier to build, preview, & release.
- Create separate dirs dist/ and dist-gh/ for tarball releases & releases to Github Pages.
