### PR TITLE
Migrate browser error detection from vite-plugin-terminal to Playwright MCP

### DIFF
--- a/.claude/commands/jp-server-start.md
+++ b/.claude/commands/jp-server-start.md
@@ -1,7 +1,13 @@
 Launch the local dev server using `yarn dev-app` in a sub-shell and let me know if
-you see any errors on its stdout / stderr. Recall that this project is
-configured to log **browser console errors** to the dev server's stdout, so
-the User's actions in the app may result in errors displaying in the dev
-server's stdout. Remember to check its stdout before and after each user
-notification, to catch any browser errors right away, and report them to the
-User for consideration / debugging.
+you see any errors on its stdout / stderr.
+
+To monitor browser console errors, use Playwright MCP to navigate to the application
+and access console messages directly. This is a cleaner approach than the previous
+vite-plugin-terminal method, as it monitors the browser directly rather than routing
+errors through the webserver.
+
+Example workflow:
+1. Start the dev server: `yarn dev-app` (in background)
+2. Use Playwright MCP to navigate to http://localhost:5173/
+3. Monitor console messages using the Playwright MCP console tools
+4. Report any errors to the User for debugging

--- a/.claude/commands/jp-server-stop.md
+++ b/.claude/commands/jp-server-stop.md
@@ -1,8 +1,8 @@
 Stop the local dev server (`vite`, from `yarn dev-app`) in the following way:
 
 If vite / yarn dev is running in your sub-shell, retrieve any last stdout /
-stderr lines from the sub-shell, report them to the User, and consider
-debugging them. Then simply type 'q' and ENTER to stop vite.
+stderr lines from the sub-shell, report them to the User if relevant, and then
+simply type 'q' and ENTER to stop vite.
 
 If that doesn't work, try running `yarn dev-app-stop` -- the `package.json` file
 defines a script `yarn dev-app-stop` that kills the pid recorded in `.vite.pid`.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ this runs, eg, `npm version minor && git push origin --tags` from package.json, 
 - **Package Manager**: Yarn 1.22.22
 - **Testing**: Vitest (unit) + Playwright (e2e) configured but not yet used for JS files
 - **Deployment**: GitHub Actions → GitHub Pages
-- **Claude Code Integration**: Browser error monitoring with vite-plugin-terminal allows Claude Code to view browser console errors
+- **Claude Code Integration**: Browser error monitoring with Playwright MCP allows Claude Code to view browser console errors directly
 
 **Future Migration Target:**
 - **Framework**: React 18 with TypeScript
@@ -184,11 +184,11 @@ this runs, eg, `npm version minor && git push origin --tags` from package.json, 
 
 This project includes special features for AI-assisted development using Claude Code:
 
-- **Real-time Error Monitoring**: Browser runtime errors appear directly in the terminal
-- **Timestamped Debugging**: Local timestamps help coordinate debugging sessions
-- **Full Stack Traces**: Complete error context with file locations and line numbers
+- **Real-time Error Monitoring**: Browser runtime errors accessible via Playwright MCP
+- **Direct Browser Access**: Monitor console messages without webserver middleware
+- **Full Console Access**: View all console messages, not just errors
 
-**⚠️ CRITICAL for Claude Code Users**: For Claude Code to view the browser console errors, it must run the dev server (`yarn dev`) in its own background bash shell. Human developers should NOT run their own `yarn dev` in a separate terminal (which is not visible to Claude Code).
+**Note for Claude Code Users**: Use Playwright MCP tools to navigate to the application and monitor browser console messages directly for debugging.
 
 ### Git Hooks
 
@@ -201,7 +201,7 @@ The hooks are configured by running `git config core.hooksPath .githooks` (step 
 
 For detailed development information, see [Maintainer Documentation](doc/maintainer/).
 
-**Note for AI Agents**: Read `CLAUDE.md` for complete development workflow guidance including error monitoring setup and limitations.
+**Note for AI Agents**: Read `CLAUDE.md` for complete development workflow guidance including Playwright MCP error monitoring setup.
 
 ## Testing
 

--- a/doc/maintainer/how-to/development-tasks.md
+++ b/doc/maintainer/how-to/development-tasks.md
@@ -730,170 +730,66 @@ const useAnimation = () => {
 
 ### Browser Error Monitoring
 
-This project includes a sophisticated error monitoring setup specifically designed for Claude Code AI-assisted development. Browser runtime errors are automatically captured and displayed in the Vite dev server terminal with timestamps and full stack traces. If Claude Code is running `yarn dev`, then it will be able to automatically detect browser console errors, report them, and hopefully fix them :).
-
-**⚠️ CRITICAL: Claude Code must run the dev server (`yarn dev`) in its own background bash shell. Human developers should NOT run `yarn dev` in their own terminal because then Claude Code won't be able to view the browser console errors.**
+This project supports browser error monitoring for Claude Code AI-assisted development using Playwright MCP. Claude Code can access browser console messages directly without requiring special Vite plugins or routing errors through the webserver. This provides a cleaner, more reliable approach to monitoring browser errors during development.
 
 ### Error Monitoring Setup
 
 #### Technology Stack
 
-- **Plugin**: `vite-plugin-terminal@1.3.0`
-- **Configuration**: Dual output to browser console and terminal
-- **Error Handlers**: Custom JavaScript error handlers in `index.html`
-- **Timestamps**: Local time format for human readability
+- **Tool**: Playwright MCP (Model Context Protocol)
+- **Access**: Direct browser console monitoring
+- **Configuration**: No special Vite configuration required
+- **Timestamps**: Browser native timestamps
 
 #### Implementation Details
 
-```typescript
-// vite.config.ts
-import Terminal from "vite-plugin-terminal";
+Claude Code uses Playwright MCP tools to interact with the browser:
 
-export default defineConfig({
-  plugins: [
-    Terminal({
-      output: ["terminal", "console"], // Show in both places
-    }),
-  ],
-});
-```
+1. **Navigate to Application**: Use Playwright MCP to open http://localhost:5173/
+2. **Monitor Console**: Use `mcp__playwright__browser_console_messages` to access console messages
+3. **Interactive Testing**: Use `mcp__playwright__browser_click` to interact with elements
 
-```javascript
-// index.html - Error handling script
-import { terminal } from "virtual:terminal";
-
-// Capture uncaught exceptions
-window.addEventListener("error", function (event) {
-  const timestamp = new Date().toLocaleString();
-  const errorMsg = `🚨 [${timestamp}] Runtime Error: ${event.message}...`;
-  terminal.error(errorMsg);
-});
-
-// Capture promise rejections
-window.addEventListener("unhandledrejection", function (event) {
-  const timestamp = new Date().toLocaleString();
-  const errorMsg = `🚨 [${timestamp}] Unhandled Promise Rejection: ${event.reason}...`;
-  terminal.error(errorMsg);
-});
-
-// Override console.error
-console.error = function (...args) {
-  originalConsoleError.apply(console, arguments);
-  if (!args[0]?.toString().includes("🚨")) {
-    const timestamp = new Date().toLocaleString();
-    terminal.error(`🚨 [${timestamp}] Console Error:`, ...args);
-  }
-};
-```
-
-#### Version Compatibility
-
-⚠️ **Important**: This project uses Vite 6.3.5 instead of the latest 7.x for compatibility reasons:
-
-- **Security**: Vite 6.3.5 was chosen to address esbuild security vulnerabilities
-- **Plugin Compatibility**: `vite-plugin-terminal` has [known issues](https://github.com/patak-dev/vite-plugin-terminal/issues/34) with Vite 7.x
-- **Workaround**: If Vite 7.x is required, implement a custom WebSocket-based error reporting solution
+This approach provides:
+- **Direct Access**: No middleware or plugins needed
+- **Full Console**: Access to all console messages, not just errors
+- **Cleaner Architecture**: Separation between dev server and error monitoring
 
 ### Usage and Best Practices
 
 #### Starting Claude Code Session
 
-**✅ CORRECT: Claude Code starts the dev server**
-
 ```bash
 # Claude Code runs this in background bash shell
-yarn dev
+yarn dev-app
 
-# Expected output in Claude's terminal:
+# Expected output:
 # VITE v6.3.5  ready in 75 ms
 # ➜  Local:   http://localhost:5173/
-# » 🧪 Terminal plugin test - this should appear in the terminal
 ```
-
-**❌ INCORRECT: Human runs their own dev server**
-
-```bash
-# DON'T DO THIS - breaks error monitoring
-# Human in their own terminal:
-yarn dev  # <- This prevents Claude from seeing errors
-```
-
-**Why this matters:**
-
-- Claude Code needs to run `yarn dev` in its own background bash shell
-- Claude uses the `BashOutput` tool to read terminal output from its own shell
-- If human runs the dev server separately, Claude cannot access that terminal output
-- Error monitoring completely fails if Claude doesn't control the dev server process
 
 #### Error Monitoring Workflow
 
-1. **Claude Code**: Starts `yarn dev` in background bash shell
-2. **Human Developer**: Opens browser to http://localhost:5173/ and interacts with application
-3. **Browser**: Generates runtime errors during interaction
-4. **Error Handlers**: Capture errors and send to Claude's terminal via plugin
-5. **Claude Code**: Uses `BashOutput` tool to read new terminal output from its own shell
-6. **Coordination**: Both parties reference timestamps for debugging
+1. **Claude Code**: Starts `yarn dev-app` in background bash shell
+2. **Claude Code**: Uses Playwright MCP to navigate to http://localhost:5173/
+3. **Human Developer**: Interacts with application in their own browser
+4. **Browser**: Generates runtime errors during interaction
+5. **Claude Code**: Uses `mcp__playwright__browser_console_messages` to access console
+6. **Coordination**: Both parties can reference browser console or Playwright output
 
-#### Example Error Output
+#### Example Usage
 
-```
-🚨 [8/14/2025, 6:09:37 AM] Runtime Error: Uncaught ReferenceError: distanceBetween is not defined
-   at http://localhost:5173/js/init/kiddopaint.js:586:14
-   Stack: ReferenceError: distanceBetween is not defined
-    at common_ev_proc (http://localhost:5173/js/init/kiddopaint.js:586:14)
-    at HTMLCanvasElement.ev_canvas (http://localhost:5173/js/init/kiddopaint.js:577:3)
-```
-
-#### Critical Limitations and Pitfalls
-
-⚠️ **BashOutput Tool Behavior**: Claude Code's `BashOutput` tool has important limitations:
-
-**How It Works:**
-
-- Only shows **NEW** output since last check
-- Once checked, previous output is "consumed" and unavailable
-- Output timestamps help identify fresh vs cached errors
-
-**Potential Issues:**
-
-- **Wrong Dev Server**: Human running their own `yarn dev` breaks everything
-- **Timing Problems**: Claude checking before errors occur misses them
-- **Premature Clearing**: Accidental checks can clear error history
-- **Sync Issues**: Claude may see old cached errors instead of current ones
-- **Lost Context**: Previous error context disappears after each `BashOutput` call
-
-**Best Practices:**
-
-1. **Claude Controls Dev Server**: Claude must run `yarn dev` in background - humans should never run it
-2. **Coordinate Timing**: Human should signal when new errors are triggered
-3. **Check Systematically**: Claude should only check output when expecting new errors
-4. **Use Timestamps**: Compare error timestamps to check timing in terminal output
-5. **Communicate Status**: Both parties should be explicit about which errors are being discussed
-6. **Browser Backup**: Human can reference browser console for complete error history
-7. **Sequential Workflow**: Process one set of errors at a time to avoid confusion
-
-#### Debugging Session Example
-
-```bash
-# ✅ CORRECT workflow:
-Claude: [starts yarn dev in background]
-Human: "I'm going to trigger some errors now"
-Human: [moves mouse in app]
-Human: "Ok, I triggered some errors at 6:09:37 AM"
-Claude: [calls BashOutput to see errors from that time]
-Claude: "I can see the distanceBetween error at 6:09:37 AM. Let me examine..."
-
-# ❌ INCORRECT workflow:
-Human: [runs own yarn dev in separate terminal]
-Human: "I'm seeing errors in my terminal"
-Claude: [calls BashOutput on its own shell]
-Claude: "I don't see any errors" # <- Problem: Claude can't see human's terminal
+```javascript
+// Claude Code workflow:
+// 1. Start dev server
+// 2. Use Playwright MCP to navigate to app
+// 3. Monitor console messages
+// 4. Check for errors as user interacts with app
 ```
 
-#### Benefits of This Setup
+#### Benefits of Playwright MCP Approach
 
-- **Real-time Debugging**: Immediate visibility into runtime errors
-- **Detailed Stack Traces**: Complete error context with file locations
-- **Timestamped History**: Coordinate debugging sessions effectively
-- **AI-Human Collaboration**: Seamless workflow for AI-assisted development
-- **No Manual Checking**: Eliminates need to manually check browser console
+- **Direct Browser Access**: No middleware or routing through webserver
+- **Cleaner Architecture**: Separation of concerns
+- **Full Console Access**: See all console messages, not just errors
+- **No Timing Issues**: Direct access eliminates BashOutput consumption problems
+- **Simpler Setup**: No special Vite plugins or configuration needed

--- a/index.html
+++ b/index.html
@@ -27,49 +27,6 @@
       window.KiddoPaint.Sprite = {};
     </script>
 
-    <!-- Runtime error handler for terminal display -->
-    <script type="module">
-      import { terminal } from "virtual:terminal";
-
-      // Test terminal logging
-      terminal.log(
-        "🧪 Terminal plugin test - this should appear in the terminal",
-      );
-
-      // Capture uncaught exceptions
-      window.addEventListener("error", function (event) {
-        const timestamp = new Date().toLocaleString();
-        const errorInfo = {
-          message: event.message,
-          filename: event.filename,
-          lineno: event.lineno,
-          colno: event.colno,
-          error: event.error ? event.error.stack : "No stack trace available",
-        };
-
-        const errorMsg = `🚨 [${timestamp}] Runtime Error: ${errorInfo.message}\n   at ${errorInfo.filename}:${errorInfo.lineno}:${errorInfo.colno}\n   Stack: ${errorInfo.error}`;
-        terminal.error(errorMsg);
-      });
-
-      // Capture unhandled promise rejections
-      window.addEventListener("unhandledrejection", function (event) {
-        const timestamp = new Date().toLocaleString();
-        const errorMsg = `🚨 [${timestamp}] Unhandled Promise Rejection: ${event.reason}\n   Stack: ${event.reason?.stack || "No stack trace available"}`;
-        terminal.error(errorMsg);
-      });
-
-      // Override console.error to also log to terminal (avoid infinite loop)
-      const originalConsoleError = console.error;
-      console.error = function (...args) {
-        originalConsoleError.apply(console, arguments);
-        // Only log to terminal if not already a terminal error message
-        if (!args[0] || !args[0].toString().includes("🚨")) {
-          const timestamp = new Date().toLocaleString();
-          terminal.error(`🚨 [${timestamp}] Console Error:`, ...args);
-        }
-      };
-    </script>
-
     <!-- Bundled KidPix JavaScript modules -->
     <script type="module" src="/src/kidpix-main.js"></script>
   </head>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "react-dom": "^19.1.0",
     "typescript": "~5.6.2",
     "vite": "^6.4.1",
-    "vite-plugin-terminal": "^1.3.0",
     "vitest": "3.2.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import Terminal from "vite-plugin-terminal";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    Terminal({
-      output: ["terminal", "console"],
-    }),
-  ],
+  plugins: [react()],
   // base: process.env.NODE_ENV === "production" ? "/kidpix/" : "/", // OLD
   // base: process.env.VITE_GITHUB_PAGES === "true" ? "/kidpix/" : "/", // OLD 2
   base: "/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,24 +413,6 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.11.tgz#1e3e8044dd053c3dfa4bbbb3861f6e180ee78343"
   integrity sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==
 
-"@rollup/plugin-strip@^3.0.2":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-strip/-/plugin-strip-3.0.4.tgz#ad623cc18cf305b484f8bf38fde4ae855c1229e4"
-  integrity sha512-LDRV49ZaavxUo2YoKKMQjCxzCxugu1rCPQa0lDYBOWLj6vtzBMr8DcoJjsmg+s450RbKbe3qI9ZLaSO+O1oNbg==
-  dependencies:
-    "@rollup/pluginutils" "^5.0.1"
-    estree-walker "^2.0.2"
-    magic-string "^0.30.3"
-
-"@rollup/pluginutils@^5.0.1":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.2.0.tgz#eac25ca5b0bdda4ba735ddaca5fbf26bd435f602"
-  integrity sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==
-  dependencies:
-    "@types/estree" "^1.0.0"
-    estree-walker "^2.0.2"
-    picomatch "^4.0.2"
-
 "@rollup/rollup-android-arm-eabi@4.42.0":
   version "4.42.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.42.0.tgz#8baae15a6a27f18b7c5be420e00ab08c7d3dd6f4"
@@ -1033,11 +1015,6 @@ escalade@^3.2.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
-estree-walker@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
-
 estree-walker@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
@@ -1256,11 +1233,6 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-kolorist@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
-  integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
-
 lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -1288,7 +1260,7 @@ lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
-magic-string@^0.30.17, magic-string@^0.30.3:
+magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
@@ -1548,15 +1520,6 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-sirv@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
-  integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
-  dependencies:
-    "@polka/url" "^1.0.0-next.24"
-    mrmime "^2.0.0"
-    totalist "^3.0.0"
-
 sirv@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.1.tgz#32a844794655b727f9e2867b777e0060fbe07bf3"
@@ -1733,11 +1696,6 @@ typescript@~5.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
-ufo@^1.1.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.1.tgz#ac2db1d54614d1b22c1d603e3aef44a85d8f146b"
-  integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==
-
 undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
@@ -1761,17 +1719,6 @@ vite-node@3.2.3:
     es-module-lexer "^1.7.0"
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-
-vite-plugin-terminal@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/vite-plugin-terminal/-/vite-plugin-terminal-1.3.0.tgz#6e0813ac9005bd61b8e7dc16dfb6eb99ea32242a"
-  integrity sha512-anqc/ok0OCid13/o5sXUXnkQz8nue4BMgV5AsMO7qVO9nTAJ0EWD/2RLZaB9rg6XNC/GiVpYT1WbFjx2k8Z9eQ==
-  dependencies:
-    "@rollup/plugin-strip" "^3.0.2"
-    debug "^4.3.4"
-    kolorist "^1.7.0"
-    sirv "^2.0.2"
-    ufo "^1.1.1"
 
 "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.4.1:
   version "6.4.1"


### PR DESCRIPTION
## Summary

This PR migrates browser console error monitoring from `vite-plugin-terminal` to Playwright MCP, providing a cleaner and more reliable architecture for Claude Code to monitor browser errors during development.

## Changes

- Removed `vite-plugin-terminal` dependency from package.json
- Removed Terminal plugin configuration from vite.config.ts
- Removed error handler scripts from index.html
- Updated Claude commands (`.claude/commands/jp-server-*.md`) to use Playwright MCP workflow
- Updated CLAUDE.md with Playwright MCP documentation
- Updated README.md Claude Code integration sections
- Updated doc/maintainer/how-to/development-tasks.md with new workflow

## Benefits

- **Direct Browser Access**: No need for webserver middleware or plugins
- **Cleaner Architecture**: Separation of concerns between dev server and error monitoring
- **Full Console Access**: See all console messages, not just errors
- **No Timing Issues**: Direct browser access eliminates BashOutput consumption problems
- **Simpler Setup**: Standard Vite configuration without additional plugins

## Testing

- ✅ Dev server starts successfully without vite-plugin-terminal
- ✅ No errors related to missing virtual:terminal imports
- ✅ Documentation updated across all files

## Related

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)