### PR TITLE
fix(tests): defensive init for headless WebGL + DOMContentLoaded race

### DIFF
--- a/js/tools/partialfx.js
+++ b/js/tools/partialfx.js
@@ -3,7 +3,7 @@ KiddoPaint.Tools.Toolbox.Ink = function () {
   this.isDown = false;
   this.size = 36;
   this.scale = 1;
-  this.gfx = fx.canvas();
+  try { this.gfx = fx.canvas(); } catch (e) { this.gfx = null; } // graceful fallback when WebGL unavailable
   this.initialClick = {};
 
   this.mousedown = function (ev) {

--- a/js/tools/wholefx.js
+++ b/js/tools/wholefx.js
@@ -24,7 +24,7 @@ window.JumbleFx = JumbleFx;
 KiddoPaint.Tools.Toolbox.WholeCanvasEffect = function () {
   var tool = this;
   this.isDown = false;
-  this.gfx = fx.canvas(); // expensive; create once
+  try { this.gfx = fx.canvas(); } catch (e) { this.gfx = null; } // graceful fallback when WebGL unavailable
   this.textureGfx = {};
   this.mainImageData = {};
   this.initialClick = {};

--- a/js/util/glfx.js
+++ b/js/util/glfx.js
@@ -770,7 +770,10 @@ window.fx = (function () {
     } catch (d) {
       a = null;
     }
-    if (!a) throw "This browser does not support WebGL";
+    if (!a) {
+      console.warn("glfx.js: WebGL not available, effects requiring WebGL will be disabled");
+      return null;
+    }
     b._ = {
       gl: a,
       isInitialized: !1,

--- a/src/kidpix-main.js
+++ b/src/kidpix-main.js
@@ -132,12 +132,21 @@ import "../js/stamps/stamps.js";
 // js/sounds/*
 import "../js/sounds/sounds.js";
 
-// Initialize the application after all modules are loaded
-document.addEventListener("DOMContentLoaded", function () {
+// Initialize the application after all modules are loaded.
+// With Vite's dev server processing 100+ module imports, DOMContentLoaded
+// may fire before this module finishes evaluating. Handle both cases.
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", function () {
+    if (typeof init_kiddo_paint === "function") {
+      init_kiddo_paint();
+    }
+  });
+} else {
+  // DOMContentLoaded already fired — init immediately
   if (typeof init_kiddo_paint === "function") {
     init_kiddo_paint();
   }
-});
+}
 
 // Export the global object for potential future use
 export default window.KiddoPaint;

--- a/tests/e2e/shared/tool-helpers.ts
+++ b/tests/e2e/shared/tool-helpers.ts
@@ -33,14 +33,15 @@ export interface WackyBrushSubtool {
 }
 
 /**
- * Initialize KidPix application and wait for it to be ready
+ * Initialize KidPix application and wait for it to be ready.
+ * We wait for #tmpCanvas to exist because it's dynamically created by
+ * init_kiddo_paint() — its presence signals the app is fully initialized.
  */
 export async function initializeKidPix(page: Page): Promise<void> {
   await page.goto("/");
   await page.waitForLoadState("networkidle");
-  await page.waitForFunction(
-    () => window.KiddoPaint && window.KiddoPaint.Current,
-  );
+  // Wait for the dynamically-created tmpCanvas, which signals init_kiddo_paint() has completed
+  await page.waitForSelector("#tmpCanvas", { timeout: 10000 });
 }
 
 /**


### PR DESCRIPTION
## Summary
Cherry-picks commit `e55d267` from the abandoned `react-ts-migration` branch before that branch is deleted. The commit wraps WebGL init and app bootstrapping in defensive checks that harden the app against headless Chromium behavior.

## What changed
- `js/util/glfx.js`: log & return `null` when WebGL is unavailable instead of throwing (previously threw an uncaught error during module evaluation)
- `js/tools/wholefx.js`, `js/tools/partialfx.js`: wrap `fx.canvas()` in try/catch so a missing WebGL doesn't kill the ES module eval chain
- `src/kidpix-main.js`: check `document.readyState` and call init immediately if `DOMContentLoaded` already fired (Vite's 100+ imports can race past the listener)
- `tests/e2e/shared/tool-helpers.ts`: wait for `#tmpCanvas` (created by `init_kiddo_paint`) instead of `KiddoPaint.Current` (set before init completes)

## Why now
The commit's original context was fixing 87 E2E failures on the `react-ts-migration` branch (which had additional React-specific tests). On current `main`, E2E tests already pass (91/28/0 before and after this change) because the extra React tests don't exist yet. But:

- The defensive improvements are independently valuable — the WebGL fallback and DOMContentLoaded readiness check are robustness wins regardless.
- Future React migration work (being re-planned with Opus 4.7) will likely re-introduce conditions where these races matter.
- Without this PR, `e55d267` is lost when `react-ts-migration` is deleted in the ongoing branch cleanup.

## Test plan
- [x] `yarn test` → 128/128 pass
- [x] `yarn build` → clean
- [x] `yarn test:e2e --project=chromium` → 91 passed, 28 skipped, 0 failed (same as main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)