### PR TITLE
fix(tests): mute audio in Playwright tests via HTMLMediaElement override

### DIFF
--- a/tests/e2e/canvas-functionality.spec.ts
+++ b/tests/e2e/canvas-functionality.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/color-picker.spec.ts
+++ b/tests/e2e/color-picker.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/electric-mixer.spec.ts
+++ b/tests/e2e/electric-mixer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/eraser.spec.ts
+++ b/tests/e2e/eraser.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 
 test("has title", async ({ page }) => {
   await page.goto("/");

--- a/tests/e2e/keyboard-shortcuts-help.spec.ts
+++ b/tests/e2e/keyboard-shortcuts-help.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 
 test.describe("Keyboard Shortcuts Help Popup", () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/line.spec.ts
+++ b/tests/e2e/line.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/moving-van.spec.ts
+++ b/tests/e2e/moving-van.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/oval.spec.ts
+++ b/tests/e2e/oval.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/paint-can.spec.ts
+++ b/tests/e2e/paint-can.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/pencil.spec.ts
+++ b/tests/e2e/pencil.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/rectangle.spec.ts
+++ b/tests/e2e/rectangle.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/shared/playwright-fixtures.ts
+++ b/tests/e2e/shared/playwright-fixtures.ts
@@ -1,0 +1,13 @@
+import { test as base } from "@playwright/test";
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      HTMLMediaElement.prototype.play = () => Promise.resolve();
+      HTMLMediaElement.prototype.pause = () => {};
+    });
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/e2e/stamps.spec.ts
+++ b/tests/e2e/stamps.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/text.spec.ts
+++ b/tests/e2e/text.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/tool-switching.spec.ts
+++ b/tests/e2e/tool-switching.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,

--- a/tests/e2e/wacky-brush.spec.ts
+++ b/tests/e2e/wacky-brush.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./shared/playwright-fixtures";
 import {
   initializeKidPix,
   setupConsoleErrorMonitoring,


### PR DESCRIPTION
## Summary
Closes #45 — `yarn test:e2e` was still making noise even with `--mute-audio`/`--disable-audio-output` browser flags in `playwright.config.ts`. This PR adds a minimal Playwright fixture that overrides `HTMLMediaElement.prototype.play/pause` to no-ops at page-init time, which silences every `new Audio()` playback the app triggers.

## Approach (simplest-first)
Rather than the belt-and-suspenders fixture on `claude/fix-bug-011CUm2fRtm5LiQCw8C6Akg4` (which mocks `Audio`, `HTMLMediaElement`, and `AudioContext` plus per-browser launch-option overrides), this keeps the existing `--mute-audio` config and adds a tiny prototype override:

```ts
HTMLMediaElement.prototype.play = () => Promise.resolve();
HTMLMediaElement.prototype.pause = () => {};
```

Works because:
- The app uses only `new Audio()` (HTMLMediaElement) — `grep -rn AudioContext js/` returns zero hits, so patching that prototype catches 100% of sound playback.
- All 16 spec files now import `test`/`expect` from `./shared/playwright-fixtures` so the init script runs on every test page.

## Verification
- [x] `yarn test:e2e --project=chromium` → 91 passed, 28 skipped, 0 failed (same as main)
- [x] `yarn test` → 128/128 pass
- [ ] **Needs human ear**: run `yarn test:e2e:headed` and confirm silence. If any sound still plays, escalate to the fuller fixture on `origin/claude/fix-bug-011CUm2fRtm5LiQCw8C6Akg4` (mocks the Audio class itself and AudioContext as well).

## Test plan
- [ ] Reviewer: `yarn test:e2e:headed` → silent during test run
- [ ] Reviewer: spot-check one spec file (e.g. `pencil.spec.ts`) to confirm the import swap is non-invasive

🤖 Generated with [Claude Code](https://claude.com/claude-code)