### PR TITLE
ci: re-enable test workflow on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
 name: Comprehensive Testing
 
-# jpp - temp disable for other workflow development
-# on:
-#   pull_request:
-#     branches: [main]
-#   workflow_dispatch:
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -18,23 +17,20 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      # - name: Run linting
-      #   run: yarn lint
-
       - name: Run unit tests with coverage
         run: yarn test:coverage
 
-      # - name: Install Playwright browsers
-      #   run: yarn playwright install --with-deps
+      - name: Install Playwright (chromium only)
+        run: yarn playwright install --with-deps chromium
 
-      # - name: Run E2E tests
-      #   run: yarn test:e2e
+      - name: Run E2E tests (chromium only)
+        run: yarn exec playwright test -- --project=chromium --workers=1 --reporter=line
 
       - name: Upload E2E test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Re-enables `.github/workflows/test.yml` (paused months ago) so PRs to `main` get gated by unit + E2E tests.
- Bumps the workflow's Node version from 20 to 24 to match the project's runtime.
- Drops the dead lint step (ESLint/Prettier were removed in 3f1155b).
- Adds back the Playwright install + run, scoped to chromium-only with `--workers=1` to match local guidance and keep CI fast/stable.

## Why

Without PR-level CI, the only signal a bad change gives is the post-merge deploy workflow failing on `main`. Re-enabling here closes that gap. Especially relevant for routine dependency bumps from Dependabot, which are about to merge.

## Local verification

- `yarn test`: 128/128 passing.
- `yarn exec playwright test -- --project=chromium --workers=1`: 91 passed, 28 skipped, 0 failed (1.6 min).
- The 28 skipped tests are pre-existing (commit 011d0cf, Nov 2025) and tracked in #84 for future re-enablement.

## Test plan

- [ ] CI workflow runs on this PR and completes green.
- [ ] After merge, future PRs see the same checks gating merge.